### PR TITLE
Options are passed as a seperate parameter (not as part of the request).

### DIFF
--- a/SyncCiviCustomPost.class.php
+++ b/SyncCiviCustomPost.class.php
@@ -116,8 +116,8 @@ class SyncCiviCustomPost {
    */
   public function sync() {
     $syncedIds = array();
-    $apiParams['options']['limit'] = 0;
-    $result = sync_civicrm_custom_post_api_wrapper($this->api_profile, $this->api_entity, $this->api_get, $apiParams);
+    $options['limit'] = 0;
+    $result = sync_civicrm_custom_post_api_wrapper($this->api_profile, $this->api_entity, $this->api_get, [], $options);
     foreach($result['values'] as $row) {
       $id = $row[$this->id_field];
       $title = $row[$this->title_field];


### PR DESCRIPTION
Before
---------
Synchronizations are restricted to a result op 25

After
-------
Synchronizations are unlimited

